### PR TITLE
NuxtからRailsにログインリクエストを送信できるようにする

### DIFF
--- a/components/LoggedIn/LoggedInAppBarAccountMenu.vue
+++ b/components/LoggedIn/LoggedInAppBarAccountMenu.vue
@@ -27,8 +27,7 @@
     <v-list-item>
       <v-list-item-content>
         <v-list-item-subtitle>
-          <!-- TODO -->
-          ユーザー名が表示されます
+          {{ $auth.user.name }}
         </v-list-item-subtitle>
       </v-list-item-content>
     </v-list-item>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -123,6 +123,9 @@ export default {
   // },
   axios: {
     baseURL: 'http://localhost:3000/',
+    // クロスドメインで認証情報を共有する
+    // https://axios.nuxtjs.org/options/#credentials
+    credentials: true
   },
   router: {
     // middleware: ['auth'],

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -35,7 +35,7 @@ export default {
 
   // Plugins to run before rendering page: https://go.nuxtjs.dev/config-plugins
   plugins: [
-    { src: '~/plugins/axios.js', ssr: false },
+    'plugins/auth',
     'plugins/axios',
     'plugins/my-inject'
   ],

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@nuxtjs/axios": "^5.13.6",
     "@nuxtjs/proxy": "^2.1.0",
     "core-js": "^3.25.3",
+    "jwt-decode": "^3.1.2",
     "nuxt": "^2.15.8",
     "nuxt-i18n": "^6.28.1",
     "vue": "^2.7.10",

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -15,10 +15,10 @@
       @submit.prevent="login"
     >
       <user-form-email
-        :email.sync="params.user.email"
+        :email.sync="params.auth.email"
       />
       <user-form-password
-        :password.sync="params.user.password"
+        :password.sync="params.auth.password"
       />
       <v-card-actions>
         <nuxt-link
@@ -58,14 +58,32 @@ export default {
     return {
       isValid: false,
       loading: false,
-      params: { user: { email: '', password: '' } },
+      // TODO: あとで削除する
+      params: { auth: { email: 'user0@example.com', password: 'password' } },
       redirectPath: $store.state.loggedIn.homePath
     }
   },
   methods: {
-    login() {
+    async login() {
       this.loading = true
+      if(this.isValid){
+        await this.$axios.post('api/v1/auth_token', this.params)
+          .then(response => this.authSuccessful(response))
+          .catch(error => this.authFailure(error))
+      }
+      this.loading = false
+    },
+    authSuccessful(response) {
+      console.log('authSuccessful', response)
+      // TODO: ログイン処理
+      // TODO: 記憶ルートリダイレクト
       this.$router.push(this.redirectPath)
+    },
+    authFailure({ response }) {
+      if(response && response.status === 404) {
+        // TODO: トースター出力
+      }
+      // TODO: エラー処理
     }
   }
 }

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -68,15 +68,20 @@ export default {
       this.loading = true
       if(this.isValid){
         await this.$axios.post('api/v1/auth_token', this.params)
-          .then(response => this.authSuccessful(response))
+          .then(response => this.authSuccessful(response.data))
           .catch(error => this.authFailure(error))
       }
       this.loading = false
     },
     authSuccessful(response) {
       console.log('authSuccessful', response)
-      // TODO: ログイン処理
+      this.$auth.login(response)
       // TODO: 記憶ルートリダイレクト
+      console.log('token', this.$auth.token)
+      console.log('expires', this.$auth.expires)
+      console.log('payload', this.$auth.payload)
+      console.log('user', this.$auth.user)
+
       this.$router.push(this.redirectPath)
     },
     authFailure({ response }) {

--- a/plugins/auth.js
+++ b/plugins/auth.js
@@ -1,0 +1,44 @@
+import jwtDecode from 'jwt-decode'
+
+class Authentication {
+  constructor(ctx) {
+    this.store = ctx.store
+    this.$axios = ctx.$axios
+  }
+
+  get token() {
+    return this.store.state.auth.token
+  }
+
+  get expires() {
+    return this.store.state.auth.expires
+  }
+
+  get payload() {
+    return this.store.state.auth.payload
+  }
+
+  get user() {
+    return this.store.state.user.current || {}
+  }
+
+  // 認証情報をVuexに保存する
+  setAuth({ token, expires, user }) {
+    const exp = expires * 1000
+    const jwtPayload = (token) ? jwtDecode(token) : {}
+
+    this.store.dispatch('getAuthToken', token)
+    this.store.dispatch('getAuthExpires', exp)
+    this.store.dispatch('getCurrentUser', user)
+    this.store.dispatch('getAuthPayload', jwtPayload)
+  }
+
+  // ログイン業務
+  login(response) {
+    this.setAuth(response)
+  }
+}
+
+export default({ store, $axios }, inject) => {
+  inject('auth', new Authentication({ store, $axios }))
+}

--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -1,17 +1,34 @@
-export default function({ $axios }) {
-  $axios.onRequest(config => {
-    config.headers.client = window.localStorage.getItem("client")
-    config.headers["access-token"] = window.localStorage.getItem("access-token")
-    config.headers.uid = window.localStorage.getItem("uid")
-    config.headers["token-type"] = window.localStorage.getItem("token-type")
-  })
+// export default function({ $axios }) {
+//   $axios.onRequest(config => {
+//     config.headers.common['X-Requested-With'] = 'XMLHttpRequest'
+//     config.headers.client = window.localStorage.getItem("client")
+//     config.headers["access-token"] = window.localStorage.getItem("access-token")
+//     config.headers.uid = window.localStorage.getItem("uid")
+//     config.headers["token-type"] = window.localStorage.getItem("token-type")
+//   })
 
-  $axios.onResponse(response => {
-    if (response.headers.client) {
-      localStorage.setItem("access-token", response.headers["access-token"])
-      localStorage.setItem("client", response.headers.client)
-      localStorage.setItem("uid", response.headers.uid)
-      localStorage.setItem("token-type", response.headers["token-type"])
-    }
+//   $axios.onResponse(response => {
+//     if (response.headers.client) {
+//       localStorage.setItem("access-token", response.headers["access-token"])
+//       localStorage.setItem("client", response.headers.client)
+//       localStorage.setItem("uid", response.headers.uid)
+//       localStorage.setItem("token-type", response.headers["token-type"])
+//     }
+//   })
+// }
+
+export default ({ $axios }) => {
+  // リクエストログ
+  $axios.onRequest((config) => {
+    config.headers.common['X-Requested-With'] = 'XMLHttpRequest'
+    console.log(config)
   })
-}
+  // レスポンスログ
+  $axios.onResponse((config) => {
+    console.log(config)
+  })
+  // エラーログ
+  $axios.onError((e) => {
+    console.log(e.response)
+  })
+ }

--- a/store/index.js
+++ b/store/index.js
@@ -23,6 +23,14 @@ export const state = () => ({
       { id: 4, name: 'MyPost04', updatedAt: '2020-04-04T12:00:00+09:00' },
       { id: 5, name: 'MyPost05', updatedAt: '2020-04-01T12:00:00+09:00' }
     ]
+  },
+  user: {
+    current: null
+  },
+  auth: {
+    token: null,
+    expires: 0,
+    payload: {}
   }
 })
 
@@ -35,6 +43,18 @@ export const getters = {
 export const mutations = {
   setCurrentPost(state, payload) {
     state.post.current = payload
+  },
+  setCurrentUser (state, payload) {
+    state.user.current = payload
+  },
+  setAuthToken (state, payload) {
+    state.auth.token = payload
+  },
+  setAuthExpires (state, payload) {
+    state.auth.expires = payload
+  },
+  setAuthPayload (state, payload) {
+    state.auth.payload = payload
   }
 }
 
@@ -47,5 +67,19 @@ export const actions = {
     const currentPost =
       state.post.list.find(post => post.id === id) || null
     commit('setCurrentPost', currentPost)
+  },
+  getCurrentUser ({ commit }, user) {
+    commit('setCurrentUser', user)
+  },
+  getAuthToken ({ commit }, token) {
+    commit('setAuthToken', token)
+  },
+  getAuthExpires ({ commit }, expires) {
+    expires = expires || 0
+    commit('setAuthExpires', expires)
+  },
+  getAuthPayload ({ commit }, jwtPayload) {
+    jwtPayload = jwtPayload || {}
+    commit('setAuthPayload', jwtPayload)
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6215,6 +6215,11 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jwt-decode@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
+  integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"


### PR DESCRIPTION
- jwt-decodeのインストール
- storeに保存されず暫く苦戦したが、原因はRails側ではなくNuxt側だった。pages/login.vueで、レスポンスを受け取るときに.then(response => this.authSuccessful(response))としていたが、.then(response => this.authSuccessful(response.data))とする必要があった。